### PR TITLE
remove typechain from repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   ],
   "scripts": {
     "build": "tsc --build",
-    "postinstall": "npx typechain --target ethers-v6 --out-dir \"./src/typechain\" \"./node_modules/@premia/v3-abi/abi/*.json\"",
     "start": "node ./dist/index.js",
     "prettier": "./node_modules/.bin/prettier --write --ignore-path .gitignore ./src/**",
     "e2e:account": "mocha --require ts-node/register test/account.ts --timeout 20000",
@@ -42,8 +41,6 @@
     "express": "^4.18.2",
     "lodash": "^4.17.21",
     "moment": "^2.29.4",
-    "typechain": "^8.3.1",
-    "typechain-target-ethers-v6": "^0.1.0",
     "typescript": "^5.2.2",
     "web3-utils": "^1.9.0",
     "winston": "^3.9.0",

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,8 @@ There are several things that are needed in order to work with the API locally. 
 - An EOA (Externally Owned Account) on the Ethereum (funded on Arbitrum) with a wallet provider such as [Metamask](https://metamask.io/)
 - An API Key from Premia (please email _support@premia.finance_ and use subject line 'API KEY REQUEST')
 - Latest version of [Docker](https://docs.docker.com/get-docker/)
-- An RPC provider (such as [Alchemy](https://www.alchemy.com/) or [Infura](https://www.infura.io/))
+- An RPC provider (such as [Alchemy](https://www.alchemy.com/) or [Infura](https://www.infura.io/)). Due 
+  to the higher RPC throughput demand for programmatic trading, a premium RPC API key may be necessary. 
 
 Example of required env. variables to be specified by API user: [.env.example](.env.example)
 

--- a/src/helpers/check.ts
+++ b/src/helpers/check.ts
@@ -5,15 +5,10 @@ import {
 } from '../types/quote'
 import { TokenBalance } from '../types/balances'
 import { Option } from '../types/validate'
-import { IPool, IPool__factory } from '../typechain'
+import { IPool, IPool__factory } from '@premia/v3-abi/typechain'
 import { createExpiration, createPoolKey } from './create'
-import {
-	privateKey,
-	rpcUrl,
-	tokenAddresses,
-	walletAddr,
-} from '../config/constants'
-import { ethers, formatEther, formatUnits, parseEther } from 'ethers'
+import { privateKey, rpcUrl, walletAddr } from '../config/constants'
+import { ethers, formatEther, parseEther } from 'ethers'
 import Logger from '../lib/logger'
 import { getPoolAddress } from './get'
 import moment from 'moment'

--- a/src/helpers/get.ts
+++ b/src/helpers/get.ts
@@ -9,7 +9,10 @@ import {
 } from '../config/constants'
 import arb from '../config/arbitrum.json'
 import arbGoerli from '../config/arbitrumGoerli.json'
-import { IPoolFactory__factory, ISolidStateERC20__factory } from '../typechain'
+import {
+	IPoolFactory__factory,
+	ISolidStateERC20__factory,
+} from '@premia/v3-abi/typechain'
 import { RejectedTokenBalance, TokenBalance } from '../types/balances'
 
 const provider = new ethers.JsonRpcProvider(rpcUrl)

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ import {
 	IPool__factory,
 	IPoolFactory__factory,
 	ISolidStateERC20__factory,
-} from './typechain'
+} from '@premia/v3-abi/typechain'
 import { difference, find, flatten, groupBy, partition, pick } from 'lodash'
 import { getBlockByTimestamp, requestDetailed } from './helpers/util'
 import moment from 'moment'

--- a/test/account.ts
+++ b/test/account.ts
@@ -15,7 +15,7 @@ import { expect } from 'chai'
 import { RejectedTokenBalance, TokenBalance } from '../src/types/balances'
 import arb from '../src/config/arbitrum.json'
 import arbGoerli from '../src/config/arbitrumGoerli.json'
-import { ISolidStateERC20__factory } from '../src/typechain'
+import { ISolidStateERC20__factory } from '@premia/v3-abi/typechain'
 import { ethers, formatUnits, MaxUint256 } from 'ethers'
 
 // NOTE: integration tests can only be run on development mode & with testnet credentials

--- a/test/expiration.ts
+++ b/test/expiration.ts
@@ -1,5 +1,4 @@
 import dotenv from 'dotenv'
-import axios from 'axios'
 import { checkEnv } from '../src/config/checkConfig'
 
 dotenv.config()

--- a/test/quoting.ts
+++ b/test/quoting.ts
@@ -27,7 +27,6 @@ import {
 } from '../src/config/constants'
 import { delay } from '../src/helpers/util'
 import { omit } from 'lodash'
-import { createExpiration, createPoolKey } from '../src/helpers/create'
 
 // NOTE: integration tests can only be run on development mode & with testnet credentials
 checkEnv(true)


### PR DESCRIPTION
Typechain is not needed anymore since we can use the @premia package to access the contract typings. 

Minor note was added that RPC provider may need to be a premium account for container to work properly.