### PR TITLE
Fix/iv multi call

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -805,7 +805,7 @@ paths:
             - api
   /oracles/iv:
     get:
-      summary: Gets the IV value for an option via an IV oracle.
+      summary: Gets the IV values for a given option expiration via an IV oracle.
       parameters:
         - name: market
           in: query
@@ -815,14 +815,6 @@ paths:
             type: string
             pattern: ^WETH$|^WBTC$|^ARB$|^LINK$|^WSTETH$|^GMX$|^MAGIC$|^SOL$|^FXS$
             example: WETH
-        - name: strike
-          in: query
-          required: true
-          description: strike price of option
-          schema:
-            type: number
-            minimum: 0
-            example: 1800
         - name: expiration
           in: query
           required: true
@@ -845,8 +837,19 @@ paths:
           content:
             application/json:
               schema:
-                type: number
-                example: 0.46
+                type: array
+                items:
+                  type: object
+                  properties:
+                    strike:
+                      type: number
+                      example: 1700
+                    iv:
+                      type: number
+                      example: 0.47
+                  required:
+                    - strike
+                    - iv
         '400':
           description: Invalid parameters supplied
           content:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -805,7 +805,7 @@ paths:
             - api
   /oracles/iv:
     get:
-      summary: Gets the IV values for a given option expiration via an IV oracle.
+      summary: Gets multiple IV values for all valid strikes for a given option expiration of an underlying market via IV oracles.
       parameters:
         - name: market
           in: query
@@ -850,6 +850,50 @@ paths:
                   required:
                     - strike
                     - iv
+        '400':
+          description: Invalid parameters supplied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        '401':
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthError'
+  /oracles/spot:
+    get:
+      summary: Gets multiple spot prices from chainlink oracles by providing an array of one or more token symbols.
+      parameters:
+        - name: market
+          in: query
+          required: true
+          description: one or more base token symbols ie [WETH, WBTC, ARB]
+          schema:
+            type: array
+            items:
+              type: string
+            minItems: 1
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    market:
+                      type: string
+                      example: WETH
+                    price:
+                      type: number
+                      example: 2500.25
+                  required:
+                    - market
+                    - price
         '400':
           description: Invalid parameters supplied
           content:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -417,15 +417,15 @@ paths:
             - api
   /pools/strikes:
     get:
-      summary: Returns all valid strike for a given market.
+      summary: Returns all valid strikes for a given market.
       parameters:
         - name: spotPrice
           in: query
-          description: unique address of the pool
+          description: spot price to use as reference for valid strikes
           required: false
           schema:
             type: number
-            example: 10000
+            example: 9846
       responses:
         '200':
           description: Successful operation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@premia/v3-api",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Containerize API for Premia V3 Orderbook",
   "author": "research@premia.finance",
   "license": "BSD-3-Clause",

--- a/src/helpers/validators.ts
+++ b/src/helpers/validators.ts
@@ -243,16 +243,12 @@ export const validateGetStrikes = ajv.compile({
 		{
 			type: 'object',
 			properties: {
-				base: {
+				market: {
 					type: 'string',
 					pattern: supportedTokens.map((token) => `^${token}$`).join('|'),
-				},
-				quote: {
-					type: 'string',
-					pattern: supportedTokens.map((token) => `^${token}$`).join('|'),
-				},
+				}
 			},
-			required: ['base', 'quote'],
+			required: ['market'],
 			additionalProperties: false,
 		},
 		{

--- a/src/helpers/validators.ts
+++ b/src/helpers/validators.ts
@@ -289,3 +289,19 @@ export const validateGetIV = ajv.compile({
 	required: ['market', 'expiration'],
 	additionalProperties: false,
 })
+
+export const validateGetSpot = ajv.compile({
+	type: 'object',
+	properties: {
+		markets: {
+			type: 'array',
+			items: {
+				type: 'string',
+				pattern: supportedTokens.map((token) => `^${token}$`).join('|'),
+			},
+			minItems: 1,
+		},
+	},
+	required: ['markets'],
+	additionalProperties: false,
+})

--- a/src/helpers/validators.ts
+++ b/src/helpers/validators.ts
@@ -246,7 +246,7 @@ export const validateGetStrikes = ajv.compile({
 				market: {
 					type: 'string',
 					pattern: supportedTokens.map((token) => `^${token}$`).join('|'),
-				}
+				},
 			},
 			required: ['market'],
 			additionalProperties: false,

--- a/src/helpers/validators.ts
+++ b/src/helpers/validators.ts
@@ -277,10 +277,6 @@ export const validateGetIV = ajv.compile({
 				.map((token) => `^${token}$`)
 				.join('|'),
 		},
-		strike: {
-			type: 'string',
-			pattern: '^[0-9]{1,}([.][0-9]*)?$',
-		},
 		expiration: {
 			type: 'string',
 			pattern: '^\\d\\d\\w\\w\\w\\d\\d$',
@@ -290,6 +286,6 @@ export const validateGetIV = ajv.compile({
 			pattern: '^[0-9]{1,}([.][0-9]*)?$',
 		},
 	},
-	required: ['market', 'strike', 'expiration'],
+	required: ['market', 'expiration'],
 	additionalProperties: false,
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,12 +67,12 @@ import {
 	GetPoolsParams,
 	GetOrdersRequest,
 	StrikesRequestSpot,
-	StrikesRequestSymbols,
 	IVRequest,
 	IVResponse,
 	SpotRequest,
 	SpotResponse,
-} from './types/validate'
+	StrikesRequestSymbol
+} from './types/validate';
 import { OptionPositions } from './types/balances'
 import { checkTestApiKey } from './helpers/auth'
 import {
@@ -1199,31 +1199,31 @@ app.get('/pools/strikes', async (req, res) => {
 
 	const request = req.query as unknown as
 		| StrikesRequestSpot
-		| StrikesRequestSymbols
+		| StrikesRequestSymbol
 
 	if (request.hasOwnProperty('spotPrice')) {
-		const market = request as StrikesRequestSpot
-		const spotPrice = parseFloat(market.spotPrice)
+		const getStrikes = request as StrikesRequestSpot
+		const spotPrice = parseFloat(getStrikes.spotPrice)
 
 		if (Number.isNaN(spotPrice)) {
 			return res.status(400).json({
 				message: 'spotPrice must be a number',
-				spotPrice: market.spotPrice,
+				spotPrice: getStrikes.spotPrice,
 			})
 		}
 
 		if (spotPrice <= 0) {
 			return res.status(400).json({
 				message: 'spotPrice must be > 0',
-				spotPrice: market.spotPrice,
+				spotPrice: getStrikes.spotPrice,
 			})
 		}
 
 		const suggestedStrikes = getSurroundingStrikes(spotPrice)
 		return res.status(200).json(suggestedStrikes)
 	} else {
-		const market = request as StrikesRequestSymbols
-		const spotPrice = await getSpotPrice(market.base)
+		const getStrikes = request as StrikesRequestSymbol
+		const spotPrice = await getSpotPrice(getStrikes.market)
 
 		if (spotPrice == undefined) {
 			return res.status(500).json({

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,8 +71,8 @@ import {
 	IVResponse,
 	SpotRequest,
 	SpotResponse,
-	StrikesRequestSymbol
-} from './types/validate';
+	StrikesRequestSymbol,
+} from './types/validate'
 import { OptionPositions } from './types/balances'
 import { checkTestApiKey } from './helpers/auth'
 import {

--- a/src/test/oracles.ts
+++ b/src/test/oracles.ts
@@ -16,15 +16,17 @@ describe('Oracles', () => {
 			},
 			params: {
 				market: 'WETH',
-				strike: 2200,
 				expiration: getMaturity(),
 			},
 		})
 
 		const iv = validGetIVResponse.data
 
-		expect(typeof iv).to.eq('number')
-		expect(iv).to.be.gt(0)
+		// returns an array but javascript calls them objects
+		expect(typeof iv).to.eq('object')
+		expect(iv.length).to.be.gt(0)
+		expect(iv[0]['strike']).to.be.gt(0)
+		expect(iv[0]['iv']).to.be.gt(0)
 	})
 
 	it('should reject invalid market', async () => {
@@ -34,7 +36,6 @@ describe('Oracles', () => {
 			},
 			params: {
 				market: 'ABCD',
-				strike: 2200,
 				expiration: getMaturity(),
 			},
 			validateStatus: function (status) {
@@ -55,7 +56,6 @@ describe('Oracles', () => {
 			},
 			params: {
 				market: 'WETH',
-				strike: 2200,
 				expiration: '26JAN24',
 			},
 			validateStatus: function (status) {
@@ -76,15 +76,17 @@ describe('Oracles', () => {
 			},
 			params: {
 				market: 'WETH',
-				strike: 2200,
 				expiration: getMaturity(),
 				spotPrice: 2200,
 			},
 		})
 
-		const iv = validGetIVResponse.data
+		const ivManualSpot = validGetIVResponse.data
 
-		expect(typeof iv).to.eq('number')
-		expect(iv).to.be.gt(0)
+		// returns an array but javascript calls them objects
+		expect(typeof ivManualSpot).to.eq('object')
+		expect(ivManualSpot.length).to.be.gt(0)
+		expect(ivManualSpot[0]['strike']).to.be.gt(0)
+		expect(ivManualSpot[0]['iv']).to.be.gt(0)
 	})
 })

--- a/src/test/oracles.ts
+++ b/src/test/oracles.ts
@@ -7,10 +7,11 @@ import { baseUrl, getMaturity } from './helpers/utils'
 // NOTE: integration tests can only be run on development mode & with testnet credentials
 checkEnv(true)
 
-const url = `${baseUrl}/oracles/iv`
-describe('Oracles', () => {
-	it('should return a valid iv value', async () => {
-		const validGetIVResponse = await axios.get(url, {
+const ivUrl = `${baseUrl}/oracles/iv`
+const spotUrl = `${baseUrl}/oracles/spot`
+describe('IV Oracles', () => {
+	it('should return a valid iv values', async () => {
+		const validGetIVResponse = await axios.get(ivUrl, {
 			headers: {
 				'x-apikey': process.env.TESTNET_ORDERBOOK_API_KEY,
 			},
@@ -30,7 +31,7 @@ describe('Oracles', () => {
 	})
 
 	it('should reject invalid market', async () => {
-		const invalidMarketIVResponse = await axios.get(url, {
+		const invalidMarketIVResponse = await axios.get(ivUrl, {
 			headers: {
 				'x-apikey': process.env.TESTNET_ORDERBOOK_API_KEY,
 			},
@@ -50,7 +51,7 @@ describe('Oracles', () => {
 	})
 
 	it('should reject iv request for a bad option expiration', async () => {
-		const invalidExpResponse = await axios.get(url, {
+		const invalidExpResponse = await axios.get(ivUrl, {
 			headers: {
 				'x-apikey': process.env.TESTNET_ORDERBOOK_API_KEY,
 			},
@@ -70,7 +71,7 @@ describe('Oracles', () => {
 	})
 
 	it('should allow a user to manually provide spot price', async () => {
-		const validGetIVResponse = await axios.get(url, {
+		const validGetIVResponse = await axios.get(ivUrl, {
 			headers: {
 				'x-apikey': process.env.TESTNET_ORDERBOOK_API_KEY,
 			},
@@ -88,5 +89,50 @@ describe('Oracles', () => {
 		expect(ivManualSpot.length).to.be.gt(0)
 		expect(ivManualSpot[0]['strike']).to.be.gt(0)
 		expect(ivManualSpot[0]['iv']).to.be.gt(0)
+	})
+})
+
+describe('Spot Oracles', () => {
+	it('should return a valid spot prices', async () => {
+		const validGetSpotResponse = await axios.get(spotUrl, {
+			headers: {
+				'x-apikey': process.env.TESTNET_ORDERBOOK_API_KEY,
+			},
+			params: {
+				markets: ['WETH', 'WBTC', 'LINK'],
+			},
+		})
+
+		const spotPrices = validGetSpotResponse.data
+
+		// returns an array but javascript calls them objects
+		expect(typeof spotPrices).to.eq('object')
+		expect(spotPrices.length).to.eq(3)
+		expect(spotPrices[0]['market']).to.eq('WETH')
+		expect(spotPrices[1]['market']).to.eq('WBTC')
+		expect(spotPrices[2]['market']).to.eq('LINK')
+		expect(spotPrices[0]['price']).to.be.gt(0)
+		expect(spotPrices[1]['price']).to.be.gt(0)
+		expect(spotPrices[2]['price']).to.be.gt(0)
+	})
+
+	it('should reject invalid market', async () => {
+		const invalidGetSpotResponse = await axios.get(spotUrl, {
+			headers: {
+				'x-apikey': process.env.TESTNET_ORDERBOOK_API_KEY,
+			},
+			params: {
+				markets: ['WETH', 'WBTC', 'XXX'],
+			},
+			validateStatus: function (status) {
+				return status <= 500
+			},
+		})
+
+		expect(invalidGetSpotResponse.status).to.eq(400)
+		// NOTE: this list is a testnet list, in production the list is different
+		expect(invalidGetSpotResponse.data[0].message).to.eq(
+			`must match pattern \"^testWETH$|^WETH$|^WBTC$|^PREMIA$|^LINK$|^USDC$|^DAI$\"`
+		)
 	})
 })

--- a/src/test/oracles.ts
+++ b/src/test/oracles.ts
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import { expect } from 'chai'
+import { isArray } from 'lodash'
 
 import { checkEnv } from '../config/checkConfig'
 import { baseUrl, getMaturity } from './helpers/utils'
@@ -23,8 +24,7 @@ describe('IV Oracles', () => {
 
 		const iv = validGetIVResponse.data
 
-		// returns an array but javascript calls them objects
-		expect(typeof iv).to.eq('object')
+		expect(isArray(iv)).to.be.true
 		expect(iv.length).to.be.gt(0)
 		expect(iv[0]['strike']).to.be.gt(0)
 		expect(iv[0]['iv']).to.be.gt(0)
@@ -84,8 +84,7 @@ describe('IV Oracles', () => {
 
 		const ivManualSpot = validGetIVResponse.data
 
-		// returns an array but javascript calls them objects
-		expect(typeof ivManualSpot).to.eq('object')
+		expect(isArray(ivManualSpot)).to.be.true
 		expect(ivManualSpot.length).to.be.gt(0)
 		expect(ivManualSpot[0]['strike']).to.be.gt(0)
 		expect(ivManualSpot[0]['iv']).to.be.gt(0)
@@ -105,8 +104,7 @@ describe('Spot Oracles', () => {
 
 		const spotPrices = validGetSpotResponse.data
 
-		// returns an array but javascript calls them objects
-		expect(typeof spotPrices).to.eq('object')
+		expect(isArray(spotPrices)).to.be.true
 		expect(spotPrices.length).to.eq(3)
 		expect(spotPrices[0]['market']).to.eq('WETH')
 		expect(spotPrices[1]['market']).to.eq('WBTC')

--- a/src/test/pool.ts
+++ b/src/test/pool.ts
@@ -96,7 +96,7 @@ describe('Pools Helpers API', () => {
 		).to.be.true
 	})
 
-	it('should get valid strikes by spotPrice', async () => {
+	it('should get valid strikes with a spotPrice', async () => {
 		const url = `${baseUrl}/pools/strikes`
 		const spotPrice = 10000
 		const getSuggestedStrikes = await axios.get(url, {
@@ -144,5 +144,21 @@ describe('Pools Helpers API', () => {
 				return nextStrike - strike === 1000
 			})
 		).to.be.true
+	})
+
+	it('should get valid strikes without a spotPrice', async () => {
+		const url = `${baseUrl}/pools/strikes`
+		const getSuggestedStrikes = await axios.get(url, {
+			headers: {
+				'x-apikey': process.env.TESTNET_ORDERBOOK_API_KEY,
+			},
+			params: {
+				market: 'WETH',
+			},
+		})
+
+		const suggestedStrikes = getSuggestedStrikes.data as number[]
+
+		expect(suggestedStrikes).not.be.empty
 	})
 })

--- a/src/types/validate.ts
+++ b/src/types/validate.ts
@@ -81,7 +81,11 @@ export interface StrikesRequestSpot {
 
 export interface IVRequest {
 	market: string
-	strike: string
 	expiration: string
 	spotPrice?: string
+}
+
+export interface IVResponse {
+	strike: number
+	iv: number
 }

--- a/src/types/validate.ts
+++ b/src/types/validate.ts
@@ -89,3 +89,12 @@ export interface IVResponse {
 	strike: number
 	iv: number
 }
+
+export interface SpotRequest {
+	markets: string[]
+}
+
+export interface SpotResponse {
+	market: string
+	price: number
+}

--- a/src/types/validate.ts
+++ b/src/types/validate.ts
@@ -70,9 +70,8 @@ export interface GetPoolsParams {
 	expiration?: string
 }
 
-export interface StrikesRequestSymbols {
-	base: string
-	quote: string
+export interface StrikesRequestSymbol {
+	market: string
 }
 
 export interface StrikesRequestSpot {


### PR DESCRIPTION
- make iv endpoint return multiple strikes for a given expiration
- create endpoint for spot oracle query (provide an array for market symbols and get back spot prices)
- update get strikes endpoint to now use spot oracle feed if user chooses not to provide spot price
- update open api yaml to reflect changes
- add e2e tests to cover changes and additions