### PR TITLE
Fix/inputs erros

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -141,14 +141,14 @@ paths:
                       type: string
                       description: filled quote ids
                       pattern: "[a-fA-F0-9]{64}"
-                      example: ba638...fb25e
+                      example: 0x3ba638...fb25e
                   failed:
                     type: array
                     items:
                       type: string
                       description: failed to fill quote ids
                       pattern: "[a-fA-F0-9]{64}"
-                      example: ba638...fb25e
+                      example: 0x3ba638...fb25e
         '400':
           description: Bad request
           content:
@@ -192,19 +192,19 @@ paths:
                     items:
                       type: string
                       pattern: '[a-fA-F0-9]{64}$'
-                      example: ba638...fb25e
+                      example: 0x3ba638...fb25e
                   failed:
                     type: array
                     items:
                       type: string
                       pattern: '[a-fA-F0-9]{64}$'
-                      example: ba638...fb25e
+                      example: 0x3ba638...fb25e
                   omitted:
                     type: array
                     items:
                       type: string
                       pattern: '[a-fA-F0-9]{64}$'
-                      example: ba638...fb25e
+                      example: 0x3ba638...fb25e
         '400':
           description: Invalid parameters supplied
           content:
@@ -285,7 +285,7 @@ paths:
           schema:
             type: string
             pattern: "^0x[a-fA-F0-9]{40}$"
-            example: ba638...fb25e
+            example: 0x3ba638...fb25e
         - name: taker
           in: query
           description: unique address of the taker (only for rfq quotes)
@@ -293,7 +293,7 @@ paths:
           schema:
             type: string
             pattern: "^0x[a-fA-F0-9]{40}$"
-            example: ba638...fb25e
+            example: 0x3ba638...fb25e
       responses:
         '200':
           description: Successful operation
@@ -491,7 +491,7 @@ paths:
           schema:
             type: string
             pattern: "^0x[a-fA-F0-9]{40}$"
-            example: ba638...fb25e
+            example: 0x3ba638...fb25e
         - name: size
           in: query
           description: number of contracts (ie 4)
@@ -515,7 +515,7 @@ paths:
           schema:
             type: string
             pattern: "^0x[a-fA-F0-9]{40}$"
-            example: ba638...fb25e
+            example: 0x3ba638...fb25e
       responses:
         '200':
           description: Successful operation
@@ -710,8 +710,16 @@ paths:
             - api
   /account/orders:
     get:
-      summary: Gets all open quotes.  Any valid orders that are fillable and present in the orderbook for the address
-        used for the containerized API will be returned. The address used is the one specified in the .env file.
+      summary: Gets all open quotes.  Any valid orders that are fillable and present in the orderbook for the given account (if specified), otherwise the address in the .env is used.
+      parameters:
+        - name: walletAddr
+          in: query
+          required: false
+          description: wallet address
+          schema:
+            type: string
+            pattern: "^0x[a-fA-F0-9]{40}$"
+            example: 0x3ba638...fb25e
       responses:
         '200':
           description: Successful operation
@@ -732,7 +740,16 @@ paths:
             - api
   /account/collateral_balances:
     get:
-      summary: Checks collateral balance for all tokens that have tradeable option markets.
+      summary: Checks collateral balance for all tokens that have tradeable option markets for the given account (if specified), otherwise the address in the .env is used.
+      parameters:
+        - name: walletAddr
+          in: query
+          required: false
+          description: wallet address
+          schema:
+            type: string
+            pattern: "^0x[a-fA-F0-9]{40}$"
+            example: 0x3ba638...fb25e
       responses:
         '200':
           description: Approved
@@ -766,7 +783,16 @@ paths:
             - api
   /account/native_balance:
     get:
-      summary: Checks the balance of ETH for the given account specified in the .env file.
+      summary: Checks the balance of ETH for the given account (if specified), otherwise the address in the .env is used.
+      parameters:
+        - name: walletAddr
+          in: query
+          required: false
+          description: wallet address
+          schema:
+            type: string
+            pattern: "^0x[a-fA-F0-9]{40}$"
+            example: 0x3ba638...fb25e
       responses:
         '200':
           description: Success
@@ -786,7 +812,16 @@ paths:
             - api
   /account/option_balances:
     get:
-      summary: Checks the balance of all option positions for the given account specified in the .env file.
+      summary: Checks the balance of all option positions for the given account (if specified), otherwise the address in the .env is used.
+      parameters:
+        - name: walletAddr
+          in: query
+          required: false
+          description: wallet address
+          schema:
+            type: string
+            pattern: "^0x[a-fA-F0-9]{40}$"
+            example: 0x3ba638...fb25e
       responses:
         '200':
           description: Success
@@ -1197,7 +1232,7 @@ components:
         provider:
           type: string
           pattern: '^0x[a-fA-F0-9]{40}$'
-          example: ba638...fb25e
+          example: 0x3ba638...fb25e
         taker:
           type: string
           pattern: '^0x[a-fA-F0-9]{40}$'
@@ -1211,7 +1246,7 @@ components:
         quoteId:
           type: string
           pattern: '[a-fA-F0-9]{64}$'
-          example: ba638...fb25e
+          example: 0x3ba638...fb25e
         ts:
           type: number
           example: 1698952534
@@ -1223,7 +1258,7 @@ components:
           items:
             type: string
             pattern: '[a-fA-F0-9]{64}$'
-            example: ba638...fb25e
+            example: 0x3ba638...fb25e
           minItems: 1
       required:
         - quoteIds
@@ -1237,7 +1272,7 @@ components:
         quoteId:
           type: string
           pattern: '[a-fA-F0-9]{64}$'
-          example: ba638...fb25e
+          example: 0x3ba638...fb25e
       required:
         - tradeSize
         - quoteId

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@premia/v3-api",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "Containerize API for Premia V3 Orderbook",
   "author": "research@premia.finance",
   "license": "BSD-3-Clause",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@premia/v3-api",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Containerize API for Premia V3 Orderbook",
   "author": "research@premia.finance",
   "license": "BSD-3-Clause",

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -101,6 +101,9 @@ export const blockByTsEndpoint =
 
 export const SECONDS_IN_YEAR = 365 * 24 * 60 * 60
 
+export const internalErrorMessage =
+	'Internal error, please contact support if issue persists.'
+
 export const vaultUserErrors = [
 	`Vault__AboveMaxSlippage`,
 	`Vault__AddressZero`,

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -101,7 +101,7 @@ export const blockByTsEndpoint =
 
 export const SECONDS_IN_YEAR = 365 * 24 * 60 * 60
 
-export const internalErrorMessage =
+export const INTERNAL_ERROR_MESSAGE =
 	'Internal error, please contact support if issue persists.'
 
 export const vaultUserErrors = [

--- a/src/helpers/get.ts
+++ b/src/helpers/get.ts
@@ -12,7 +12,6 @@ import {
 	SECONDS_IN_YEAR,
 	supportedTokens,
 	tokenAddr,
-	walletAddr,
 	prodTokenAddr,
 } from '../config/constants'
 import { delay } from './util'
@@ -68,7 +67,7 @@ export function getTokenByAddress(tokenObject: TokenAddr, address: string) {
 
 // NOTE: this returns the balance in human-readable format (number)
 // IMPORTANT: Promise.allSettled works here because we do not do any on-chain tx
-export async function getBalances() {
+export async function getBalances(queryWallet: string) {
 	const promiseAll = await Promise.allSettled(
 		supportedTokens.map(async (token) => {
 			const erc20 = ISolidStateERC20__factory.connect(
@@ -76,8 +75,9 @@ export async function getBalances() {
 				provider
 			)
 			const decimals = await erc20.decimals()
+
 			const balance: number = parseFloat(
-				formatUnits(await erc20.balanceOf(walletAddr), Number(decimals))
+				formatUnits(await erc20.balanceOf(queryWallet), Number(decimals))
 			)
 
 			const tokenBalance: TokenBalance = {

--- a/src/helpers/validators.ts
+++ b/src/helpers/validators.ts
@@ -89,6 +89,18 @@ export const validatePositionManagement = ajv.compile({
 	maxItems: 1000,
 })
 
+export const validateGetBalance = ajv.compile({
+	type: 'object',
+	properties: {
+		walletAddr: {
+			type: 'string',
+			pattern: '^0x[a-fA-F0-9]{40}$',
+		},
+	},
+	required: [],
+	additionalProperties: false,
+})
+
 export const validateFillQuotes = ajv.compile({
 	type: 'array',
 	items: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ import {
 	vaults,
 	prodTokenAddr,
 	vaultUserErrors,
-	internalErrorMessage,
+	INTERNAL_ERROR_MESSAGE,
 } from './config/constants'
 import {
 	FillableQuote,
@@ -255,7 +255,7 @@ app.post('/orderbook/quotes', async (req, res) => {
 	} catch (e) {
 		Logger.error(e)
 		return res.status(500).json({
-			message: internalErrorMessage,
+			message: INTERNAL_ERROR_MESSAGE,
 		})
 	}
 
@@ -325,7 +325,7 @@ app.patch('/orderbook/quotes', async (req, res) => {
 	} catch (e) {
 		Logger.error(e)
 		return res.status(500).json({
-			message: internalErrorMessage,
+			message: INTERNAL_ERROR_MESSAGE,
 		})
 	}
 
@@ -558,7 +558,7 @@ app.delete('/orderbook/quotes', async (req, res) => {
 	} catch (e) {
 		Logger.error(e)
 		return res.status(500).json({
-			message: internalErrorMessage,
+			message: INTERNAL_ERROR_MESSAGE,
 		})
 	}
 
@@ -712,7 +712,7 @@ app.get('/orderbook/quotes', async (req, res) => {
 	} catch (e) {
 		Logger.error(e)
 		return res.status(500).json({
-			message: internalErrorMessage,
+			message: INTERNAL_ERROR_MESSAGE,
 		})
 	}
 
@@ -755,7 +755,7 @@ app.get('/orderbook/orders', async (req, res) => {
 	} catch (e) {
 		Logger.error(e)
 		return res.status(500).json({
-			message: internalErrorMessage,
+			message: INTERNAL_ERROR_MESSAGE,
 		})
 	}
 
@@ -915,7 +915,7 @@ app.get('/account/option_balances', async (req, res) => {
 	} catch (e) {
 		Logger.error(e)
 		return res.status(500).json({
-			message: internalErrorMessage,
+			message: INTERNAL_ERROR_MESSAGE,
 		})
 	}
 
@@ -951,7 +951,7 @@ app.get('/account/orders', async (req, res) => {
 	} catch (e) {
 		Logger.error(e)
 		return res.status(500).json({
-			message: internalErrorMessage,
+			message: INTERNAL_ERROR_MESSAGE,
 		})
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,6 @@ import {
 	EthersError,
 	NonceManager,
 	BigNumberish,
-	ZeroAddress,
 } from 'ethers'
 
 import Logger from './lib/logger'
@@ -48,6 +47,7 @@ import {
 	vaults,
 	prodTokenAddr,
 	vaultUserErrors,
+	internalErrorMessage,
 } from './config/constants'
 import {
 	FillableQuote,
@@ -253,7 +253,7 @@ app.post('/orderbook/quotes', async (req, res) => {
 	} catch (e) {
 		Logger.error(e)
 		return res.status(500).json({
-			message: e,
+			message: internalErrorMessage,
 		})
 	}
 
@@ -323,7 +323,7 @@ app.patch('/orderbook/quotes', async (req, res) => {
 	} catch (e) {
 		Logger.error(e)
 		return res.status(500).json({
-			message: e,
+			message: internalErrorMessage,
 		})
 	}
 
@@ -556,7 +556,7 @@ app.delete('/orderbook/quotes', async (req, res) => {
 	} catch (e) {
 		Logger.error(e)
 		return res.status(500).json({
-			message: e,
+			message: internalErrorMessage,
 		})
 	}
 
@@ -710,7 +710,7 @@ app.get('/orderbook/quotes', async (req, res) => {
 	} catch (e) {
 		Logger.error(e)
 		return res.status(500).json({
-			message: e,
+			message: internalErrorMessage,
 		})
 	}
 
@@ -753,7 +753,7 @@ app.get('/orderbook/orders', async (req, res) => {
 	} catch (e) {
 		Logger.error(e)
 		return res.status(500).json({
-			message: e,
+			message: internalErrorMessage,
 		})
 	}
 
@@ -901,7 +901,7 @@ app.get('/account/option_balances', async (req, res) => {
 	} catch (e) {
 		Logger.error(e)
 		return res.status(500).json({
-			message: e,
+			message: internalErrorMessage,
 		})
 	}
 
@@ -925,7 +925,7 @@ app.get('/account/orders', async (req, res) => {
 	} catch (e) {
 		Logger.error(e)
 		return res.status(500).json({
-			message: e,
+			message: internalErrorMessage,
 		})
 	}
 

--- a/src/types/validate.ts
+++ b/src/types/validate.ts
@@ -70,6 +70,10 @@ export interface GetPoolsParams {
 	expiration?: string
 }
 
+export interface GetBalance {
+	walletAddr?: string
+}
+
 export interface StrikesRequestSymbol {
 	market: string
 }


### PR DESCRIPTION
- Fix 500 error codes to produce generic message for ALL http proxy POST/GET requests
- add optional param to query an account other than the one in the container for:
- GET account/orders
- GET account/balances
- GET account/native_balance
- GET account/option_balances
-  add test coverage for 3 out of 4 GET requests (option_balances requires moralis support)
- increment vs to 0.4.0