### PR TITLE
Feat/rfq helpers

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1000,7 +1000,7 @@ paths:
             example: 4
         - name: direction
           in: query
-          description: direction of trade (buy or sell)
+          description: direction of trade (for the requester)
           required: true
           schema:
             type: string
@@ -1084,6 +1084,125 @@ paths:
                 properties:
                   market:
                     $ref: "#/components/schemas/VaultResponse"
+        '400':
+          description: Invalid parameters supplied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        '401':
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthError'
+      security:
+        - api_key:
+            - api
+  /rfq/request:
+    get:
+      summary: This endpoint is strictly related to the RFQ network.  It is a helper end point that will format RFQ requests to publish to the RFQ Network. The object returned from this endpoint must be published to the RFQ Channel of websockets (see ws instructions on how to do this).
+      parameters:
+        - name: base
+          in: query
+          required: true
+          description: base token symbol (ie WETH)
+          schema:
+            type: string
+            example: WETH
+        - name: quote
+          in: query
+          required: true
+          description: quote token symbol (ie USDC)
+          schema:
+            type: string
+            example: USDC
+        - name: expiration
+          in: query
+          required: true
+          description: option expiration (ie 03NOV23)
+          schema:
+            type: string
+            example: 03NOV23
+        - name: strike
+          in: query
+          required: true
+          description: option strike (ie 1800)
+          schema:
+            type: number
+            minimum: 0
+            example: 1800
+        - name: type
+          in: query
+          description: C or P
+          required: true
+          schema:
+            type: string
+            pattern: ^C$|^P$
+            example: P
+        - name: size
+          in: query
+          description: number of contracts (ie 4)
+          required: true
+          schema:
+            type: number
+            minimum: 0
+            example: 4
+        - name: direction
+          in: query
+          description: direction of trade (for the requester)
+          required: true
+          schema:
+            type: string
+            example: buy
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    example: 'RFQ'
+                  body:
+                    type: object
+                    properties:
+                      poolKey:
+                        type: object
+                        properties:
+                          base:
+                            type: string
+                            example: 0x...4cFF2
+                          quote:
+                            type: string
+                            example: 0x...4cFF2
+                          oraclerAdapter:
+                            type: string
+                            example: 0x...4cFF2
+                          strike:
+                            type: string
+                            example: '2900000000000000000000'
+                          maturity:
+                            type: number
+                            example: 1709066397
+                          isCallPool:
+                            type: boolean
+                            example: true
+                      side:
+                        type: string
+                        pattern: ^bid$|^ask$
+                        example: 'ask'
+                      chainId:
+                        type: string
+                        example: '42161'
+                      size:
+                        type: string
+                        example: '1000000000000000000'
+                      taker:
+                        type: string
+                        example: 0x...4cFF2
         '400':
           description: Invalid parameters supplied
           content:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@premia/v3-api",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Containerize API for Premia V3 Orderbook",
   "author": "research@premia.finance",
   "license": "BSD-3-Clause",

--- a/src/helpers/create.ts
+++ b/src/helpers/create.ts
@@ -10,7 +10,7 @@ import {
 	PoolKey,
 	ReturnedOrderbookQuote,
 } from '../types/quote'
-import { Option, VaultQuoteRequest, VaultTradeRequest } from '../types/validate'
+import { Option, QuoteRequest, VaultTradeRequest } from '../types/validate'
 import { PublishQuoteRequest } from '../types/validate'
 import { spotOracleAddr, tokenAddr } from '../config/constants'
 import { getTokenByAddress } from './get'
@@ -125,7 +125,7 @@ export function createReturnedQuotes(
 	}
 }
 export function createPoolKey(
-	quote: PublishQuoteRequest | Option | VaultTradeRequest | VaultQuoteRequest,
+	quote: PublishQuoteRequest | Option | VaultTradeRequest | QuoteRequest,
 	expiration?: number
 ): PoolKey {
 	return {

--- a/src/helpers/validators.ts
+++ b/src/helpers/validators.ts
@@ -313,7 +313,7 @@ export const validateGetSpot = ajv.compile({
 	additionalProperties: false,
 })
 
-export const validateVaultQuote = ajv.compile({
+export const validateQuoteRequest = ajv.compile({
 	type: 'object',
 	properties: {
 		...validateOptionEntity,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1642,7 +1642,7 @@ app.get('/rfq/message', async (req, res) => {
 			side: quoteRequest.direction === 'buy' ? 'ask' : 'bid',
 			chainId: chainId,
 			size: parseEther(quoteRequest.size).toString(),
-			taker: walletAddr,
+			taker: walletAddr.toLowerCase(),
 		},
 	}
 

--- a/src/test/vaults.ts
+++ b/src/test/vaults.ts
@@ -99,6 +99,7 @@ describe('Vault Quotes', () => {
 		)
 	})
 
+	// NOTE: This validation covers BOTH vaults/quote & rfq/request as they share the same validation check
 	it('should reject bad param schema', async () => {
 		const invalidBaseQuote = await axios.get(vaultQuoteUrl, {
 			headers: {

--- a/src/test/ws.ts
+++ b/src/test/ws.ts
@@ -35,7 +35,7 @@ const quote: PublishQuoteRequest = {
 	base: 'testWETH',
 	quote: 'USDC',
 	expiration: getMaturity(),
-	strike: 2200,
+	strike: 2900,
 	type: `C`,
 	side: 'ask',
 	size: 1,
@@ -44,6 +44,13 @@ const quote: PublishQuoteRequest = {
 }
 
 let poolAddress: string
+
+/*
+NOTE:
+rfq/requests is a REST API endpoint that is used within ws tests. Since it shares the same validation
+schema as vaults/quote, there is no test coverage for validation on rfq/request.  The ws tests implicitly
+include coverage for rfq/requests
+ */
 
 before(async () => {
 	const deployment = await deployPools([quote])
@@ -199,12 +206,12 @@ describe('WS streaming', () => {
 				'x-apikey': process.env.MAINNET_ORDERBOOK_API_KEY,
 			},
 			params: {
-				base: 'WETH',
-				quote: 'USDC',
-				expiration: getMaturity(),
-				strike: 2900,
-				type: 'C',
-				size: 1,
+				base: quote.base,
+				quote: quote.quote,
+				expiration: quote.expiration,
+				strike: quote.strike,
+				type: quote.type,
+				size: quote.size,
 				direction: 'buy',
 			},
 		})
@@ -271,12 +278,12 @@ describe('RFQ WS flow', () => {
 				'x-apikey': process.env.MAINNET_ORDERBOOK_API_KEY,
 			},
 			params: {
-				base: 'WETH',
-				quote: 'USDC',
-				expiration: getMaturity(),
-				strike: 2900,
-				type: 'C',
-				size: 1,
+				base: quote.base,
+				quote: quote.quote,
+				expiration: quote.expiration,
+				strike: quote.strike,
+				type: quote.type,
+				size: quote.size,
 				direction: 'sell',
 			},
 		})

--- a/src/types/validate.ts
+++ b/src/types/validate.ts
@@ -1,5 +1,7 @@
 // validateOptionEntity & validatePositionManagement
 // NOTE: Returned Quote Objects include Option type
+import { PoolKey } from './quote'
+
 export interface Option {
 	base: string //token name | token address
 	quote: string //token name | token address
@@ -102,7 +104,7 @@ export interface SpotResponse {
 	price: number
 }
 
-export interface VaultQuoteRequest extends Omit<Option, 'strike'> {
+export interface QuoteRequest extends Omit<Option, 'strike'> {
 	strike: string
 	size: string
 	direction: 'buy' | 'sell'
@@ -128,4 +130,15 @@ export interface VaultQuoteResponse {
 	market: VaultMarket
 	quote: number
 	takerFee: number
+}
+
+export interface RFQRequestResponse {
+	type: 'RFQ'
+	body: {
+		poolKey: PoolKey
+		side: 'buy' | 'sell'
+		chainId: string
+		size: string
+		taker: string
+	}
 }


### PR DESCRIPTION
A new endpoint was created within the REST API to create/format an RFQ message to be published within our RFQ network.  A user can how first use this endpoint to generate the object needed, and then use it to PUBLISH via websocket making the life cycle of a programmatic RFQ user easier.